### PR TITLE
Ajout d'un bouton qui permet d'interagir avec l'historique des requêtes 

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,10 +44,10 @@
             <div id = "bdd"></div>
             <div id = "boutons">
                 <button id = "accueil">Accueil</button>
+                <button id = "historique">Historique</button>
                 <button id = "lancer">Exécution</button>
                 <button id = "tables">Tables</button>
                 <button id = "schema">Schéma</button>
-                <button id = "historique">Historique</button>
             </div>
         </header>
         <section id = "interface">

--- a/index.html
+++ b/index.html
@@ -47,6 +47,7 @@
                 <button id = "lancer">Exécution</button>
                 <button id = "tables">Tables</button>
                 <button id = "schema">Schéma</button>
+                <button id = "historique">Historique</button>
             </div>
         </header>
         <section id = "interface">

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -373,41 +373,8 @@
         });
         
         $("#information").append(bds);
-        // test : essai ajout d'un bouton pour masquer information
-        $("#information").append('<button id="toggleInformation">Masquer Information</button>');
     }
 
-    $(document).ready(function() {
-        // Ajout des styles pour #information et #droite
-        $("<style>")
-            .prop("type", "text/css")
-            .html(`
-                #information {
-                    width: 300px; /* Ajustez cette valeur selon vos besoins */
-                    float: left;
-                }
-
-                #droite {
-                    width: calc(100% - 300px); /* Ajustez cette valeur selon vos besoins */
-                    float: left;
-                }
-            `)
-            .appendTo("head");
-        $("#toggleInformation").click(function() {
-            var information = $("#information");
-            var droite = $("#droite");
-
-            if (information.is(":visible")) {
-                information.hide();
-                droite.css("width", "100%");
-                $(this).text("Afficher Information");
-            } else {
-                information.show();
-                droite.css("width", "40%"); //test : verifier la valeur
-                $(this).text("Masquer Information");
-            }
-        });
-    });
     
     // Chargemet d'un cours et affichage de celui-ci
     function lancementCours(cours) {

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -169,12 +169,16 @@
 
         var boutonExporter = $("<button>").html("Fichier SQL").css({
             marginLeft: '10px',
-            padding: '5px 10px',
+            padding: '6px 12px',
             backgroundColor: '#008CBA',
             color: 'white',
             border: 'none',
             borderRadius: '3px',
-            cursor: 'pointer'
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            whiteSpace: 'nowrap'
         }).click(function () {
             var historiqueTexte = historiqueRequetes.join(";\n\n");
             var blob = new Blob([historiqueTexte], {type: "text/plain;charset=utf-8"});

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -156,7 +156,11 @@
             color: 'white',
             border: 'none',
             borderRadius: '3px',
-            cursor: 'pointer'
+            cursor: 'pointer',
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            whiteSpace: 'nowrap'
         }).click(function () {
             var historiqueTexte = historiqueRequetes.join(";\n\n");
             navigator.clipboard.writeText(historiqueTexte).then(function () {
@@ -190,15 +194,24 @@
             URL.revokeObjectURL(url);
         });
 
-        var fermer = $("<button>").html("&times;").css({
-            marginLeft: '10px',
-            border: 'none',
-            background: 'transparent',
-            fontSize: '20px',
-            cursor: 'pointer'
-        }).click(function () {
-            conteneur.remove();
-        });
+        var fermer = $("<button>")
+            .html("&times;")
+            .attr('aria-label', 'Fermer')
+            .css({
+                marginLeft: '10px',
+                border: 'none',
+                background: 'transparent',
+                color: '#000',
+                fontSize: '28px',
+                padding: '6px 10px',
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                whiteSpace: 'nowrap'
+            }).click(function () {
+                conteneur.remove();
+            });
 
         header.css({ display: 'flex', alignItems: 'center' });
         header.append(titre).append(boutonCopier).append(boutonExporter).append(fermer);
@@ -238,13 +251,17 @@
                 });
 
                 var boutonSupprimer = $("<button>").html("X").css({
-                    marginLeft: '10px',
-                    padding: '5px 10px',
+                    marginLeft: '3px',
+                    padding: '3px 6px',
                     backgroundColor: '#f44336',
                     color: 'white',
                     border: 'none',
                     borderRadius: '3px',
-                    cursor: 'pointer'
+                    cursor: 'pointer',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    whiteSpace: 'nowrap'
                 }).click(function () {
                     var originalIndex = historiqueRequetes.length - 1 - i;
                     if (originalIndex > -1) {

--- a/lib/interface.js
+++ b/lib/interface.js
@@ -2,7 +2,7 @@
 (function () {
     "use strict";
     
-    var ecran = $("#interface"), hauteur, db, editeur, petit = false;
+    var ecran = $("#interface"), hauteur, db, editeur, petit = false, historiqueRequetes = [];
     
     function tropPetit() {
         petit = true;
@@ -56,6 +56,9 @@
             $("#resultat").append($("<div>").html("<strong>Attention :</strong><br>Base de données non choisie").css("color", "red"));
         } else {
             sql = editeur.getValue();
+            if (sql.trim()) {
+                historiqueRequetes.push(sql);
+            }
             try {
                 resultat = db.exec(sql)[0];
             } catch (error) {
@@ -116,6 +119,150 @@
         window.open(png);
     }
     
+    // Affichage de l'historique des requêtes
+    function afficherHistorique() {
+        if ($("#historique-conteneur").length) {
+            $("#historique-conteneur").remove();
+            return;
+        }
+
+        var conteneur = $("<div>").attr("id", "historique-conteneur").css({
+            position: 'absolute',
+            top: '60px',
+            right: '10px',
+            width: '40%',
+            maxWidth: '500px',
+            maxHeight: 'calc(100% - 80px)',
+            backgroundColor: '#f9f9f9',
+            border: '1px solid #ccc',
+            borderRadius: '5px',
+            boxShadow: '0 2px 10px rgba(0,0,0,0.1)',
+            zIndex: 1001,
+            display: 'flex',
+            flexDirection: 'column'
+        });
+
+        var header = $("<div>").css({
+            padding: '10px',
+            borderBottom: '1px solid #ccc',
+            backgroundColor: '#eee'
+        });
+
+        var titre = $("<h4>").html("Historique des requêtes").css({ margin: 0, flexGrow: 1 });
+        var boutonCopier = $("<button>").html("Copier").css({
+            marginLeft: '10px',
+            padding: '5px 10px',
+            backgroundColor: '#4CAF50',
+            color: 'white',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'pointer'
+        }).click(function () {
+            var historiqueTexte = historiqueRequetes.join(";\n\n");
+            navigator.clipboard.writeText(historiqueTexte).then(function () {
+                boutonCopier.html("Copié !");
+                setTimeout(function () {
+                    boutonCopier.html("Copier");
+                }, 2000);
+            });
+        });
+
+        var boutonExporter = $("<button>").html("Fichier SQL").css({
+            marginLeft: '10px',
+            padding: '5px 10px',
+            backgroundColor: '#008CBA',
+            color: 'white',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'pointer'
+        }).click(function () {
+            var historiqueTexte = historiqueRequetes.join(";\n\n");
+            var blob = new Blob([historiqueTexte], {type: "text/plain;charset=utf-8"});
+            var url = URL.createObjectURL(blob);
+            var a = $("<a>").attr("href", url).attr("download", "historique.sql").css("display", "none");
+            $("body").append(a);
+            a[0].click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        });
+
+        var fermer = $("<button>").html("&times;").css({
+            marginLeft: '10px',
+            border: 'none',
+            background: 'transparent',
+            fontSize: '20px',
+            cursor: 'pointer'
+        }).click(function () {
+            conteneur.remove();
+        });
+
+        header.css({ display: 'flex', alignItems: 'center' });
+        header.append(titre).append(boutonCopier).append(boutonExporter).append(fermer);
+        conteneur.append(header);
+
+        var listeConteneur = $("<div>").css({
+            padding: '10px',
+            overflowY: 'auto'
+        });
+
+        if (historiqueRequetes.length === 0) {
+            listeConteneur.append($("<p>").html("Aucune requête exécutée."));
+        } else {
+            var liste = $("<ul>").css({ listStyle: 'none', padding: 0, margin: 0 });
+            $.each(historiqueRequetes.slice().reverse(), function (i, requete) {
+                var item = $("<li>").css({ display: 'flex', alignItems: 'center', marginBottom: '5px' });
+                var pre = $("<pre>").html(requete).css({
+                    cursor: 'pointer',
+                    padding: '8px',
+                    backgroundColor: '#fff',
+                    border: '1px solid #ddd',
+                    borderRadius: '3px',
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-all',
+                    flexGrow: 1,
+                    margin: 0
+                }).hover(function () {
+                    $(this).css('backgroundColor', '#eef');
+                }, function () {
+                    $(this).css('backgroundColor', '#fff');
+                });
+
+                pre.click(function () {
+                    editeur.setValue(requete);
+                    editeur.gotoLine(1);
+                    conteneur.remove();
+                });
+
+                var boutonSupprimer = $("<button>").html("X").css({
+                    marginLeft: '10px',
+                    padding: '5px 10px',
+                    backgroundColor: '#f44336',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '3px',
+                    cursor: 'pointer'
+                }).click(function () {
+                    var originalIndex = historiqueRequetes.length - 1 - i;
+                    if (originalIndex > -1) {
+                        historiqueRequetes.splice(originalIndex, 1);
+                    }
+                    item.remove();
+                    if (historiqueRequetes.length === 0) {
+                        liste.remove();
+                        listeConteneur.append($("<p>").html("Aucune requête exécutée."));
+                    }
+                });
+
+                item.append(pre);
+                item.append(boutonSupprimer);
+                liste.append(item);
+            });
+            listeConteneur.append(liste);
+        }
+        conteneur.append(listeConteneur);
+        $("body").append(conteneur);
+    }
+
     // Lecture d'une base de données
     function lecture(fichier) {
         $("#bdd").html(fichier.replace("bases/", "").replace(".sqlite", ""));
@@ -205,8 +352,41 @@
         });
         
         $("#information").append(bds);
+        // test : essai ajout d'un bouton pour masquer information
+        $("#information").append('<button id="toggleInformation">Masquer Information</button>');
     }
-    
+
+    $(document).ready(function() {
+        // Ajout des styles pour #information et #droite
+        $("<style>")
+            .prop("type", "text/css")
+            .html(`
+                #information {
+                    width: 300px; /* Ajustez cette valeur selon vos besoins */
+                    float: left;
+                }
+
+                #droite {
+                    width: calc(100% - 300px); /* Ajustez cette valeur selon vos besoins */
+                    float: left;
+                }
+            `)
+            .appendTo("head");
+        $("#toggleInformation").click(function() {
+            var information = $("#information");
+            var droite = $("#droite");
+
+            if (information.is(":visible")) {
+                information.hide();
+                droite.css("width", "100%");
+                $(this).text("Afficher Information");
+            } else {
+                information.show();
+                droite.css("width", "40%"); //test : verifier la valeur
+                $(this).text("Masquer Information");
+            }
+        });
+    });
     
     // Chargemet d'un cours et affichage de celui-ci
     function lancementCours(cours) {
@@ -320,6 +500,7 @@
     $("#lancer").click(execution);
     $("#tables").click(afficherContenu);
     $("#schema").click(afficherSchema);
+    $("#historique").click(afficherHistorique);
     
     // Permet l'exécution de la requête via CTRL + Enter
     $(document).on('keydown', function (e) {
@@ -329,10 +510,11 @@
     });
     
     // Permet la gestion du changement de taille de la fenêtre
+    // Test taille originale : 400px nouvelle 600px
     $(window).on("resize", function () {
         hauteur = (window.innerHeight - $("header").height() - $("footer").height());
         ecran.css("height", hauteur + "px");
-        if (hauteur < 400) {
+        if (hauteur < 600) {
             tropPetit();
         } else {
             if (petit) {
@@ -344,7 +526,7 @@
 
     hauteur = (window.innerHeight - $("header").height() - $("footer").height());
     ecran.css("height", hauteur + "px");
-    if (hauteur < 400) {
+    if (hauteur < 600) {
         tropPetit();
     } else {
         debut();


### PR DESCRIPTION
_Le but est de permettre aux étudiant.es de garder plus facilement une trace de leur travail._
Ajout d'un bouton "Historique" qui ouvre un overlay affichant l'historique des requêtes de la session.
Il est possible de : 
- supprimer des requêtes de l'historique, 
- de cliquer dessus pour les remettre dans la zone de rédaction des requêtes, 
- de les exporter (dans le presse papier ou dans un fichier SQL)

<img width="2310" height="1116" alt="image" src="https://github.com/user-attachments/assets/dbe056fb-37e9-4a5b-927e-ce53329a29f0" />

Actuellement le bouton est affiché sur toutes les pages, je ne sais s'il faut le laisser visible sur l'accueil (je l'ai laisser car il reste utilisable).